### PR TITLE
Downtime and ftp

### DIFF
--- a/darwinpush/__init__.py
+++ b/darwinpush/__init__.py
@@ -1,3 +1,8 @@
-from darwinpush.client import Client
+from enum import Enum
+class Source(Enum):
+    stomp = 1
+    ftp_log = 2
+    fpt_snapshot = 3
 
+from darwinpush.client import Client
 from darwinpush.listener import Listener

--- a/darwinpush/client.py
+++ b/darwinpush/client.py
@@ -6,7 +6,7 @@ import pyxb.utils.domutils as domutils
 import darwinpush.xb.pushport as pp
 
 from darwinpush.parser import Parser
-from darwinpush import ftp
+from darwinpush import ftp, Source
 
 import enum
 import multiprocessing
@@ -316,7 +316,7 @@ class StompClient:
             try:
                 decompressed_data = zlib.decompress(message, 16+zlib.MAX_WBITS)
                 try:
-                    self.cb._on_message(headers, decompressed_data, "stomp")
+                    self.cb._on_message(headers, decompressed_data, Source.stomp)
                 except Exception as e:
                     log.exception("Exception occurred parsing DARWIN message: {}.".format(decompressed_data))
                     self.on_local_error(Error(ErrorType.ParseError, decompressed_data, e))

--- a/darwinpush/client.py
+++ b/darwinpush/client.py
@@ -139,6 +139,8 @@ class Client:
                         <=0, then the snapshot for the day will be downloaded
                              and applied, and also all the logs.
 
+                             NOT YET IMPLEMENTED.
+
                         >0,  all the required logs are downloaded. This means no
                              logs if less than 5 min (300 s) downtime, as Darwin
                              holds 5 minutes of messages in the queue before it

--- a/darwinpush/ftp.py
+++ b/darwinpush/ftp.py
@@ -3,6 +3,7 @@ import datetime
 import re
 
 import pyxb.utils.domutils as domutils
+from darwinpush import Source
 
 import logging
 log = logging.getLogger("ftp")
@@ -106,7 +107,7 @@ def login(ftp, user, passwd):
 def get_logs(ftp, client, date):
     fnames = log_filenames(ftp, date)
     def callback(msg):
-        return client.on_ftp_message(msg, source="FTP/log")
+        return client.on_ftp_message(msg, source=Source.ftp_log)
 
     for f in fnames:
         # TODO filter out duplicate messages, if any

--- a/darwinpush/ftp.py
+++ b/darwinpush/ftp.py
@@ -1,0 +1,168 @@
+import ftplib
+import datetime
+import re
+
+import logging
+log = logging.getLogger("ftp")
+
+ftp_server = "datafeeds.nationalrail.co.uk"
+
+# Downtime required to need logs from Darwin.
+log_threshold = datetime.timedelta(minutes=5)
+
+# Downtime required to need a snapshot.
+snapshot_threshold = datetime.timedelta(days=1)
+
+# A downtime <=0 downlods the snapshot and all the logs.
+
+
+_snapshot_pattern = re.compile("^([0-9]{4})([0-9]{2})([0-9]{2}).*_v8\.xml\.gz$")
+_log_pattern = re.compile(
+    "^pPortData.log.([0-9]{4})-([0-9]{2})-([0-9]{2})-([0-9]{2})-([0-9]{2})$"
+)
+
+class LoginFail(Exception): pass
+
+
+def fetchAll(self, client, downtime, server=ftp_server, user=None, passwd=None):
+    """Download all the FTP files required, parse them and pass them to the
+    client.
+
+    It connects to the FTP server, downloads the required files and passes the
+    messages to the client, and disconnects from the FTP server.
+
+    This method blocks until it's done processing.
+
+    Args:
+        client: Must have a on_message(headers, message, source) method, which
+              will be called for every valid message parsed.
+
+        downtime: An int representing the number of seconds of downtime. It
+                can also be a datetime.timedelta representing the downtime.
+
+                If the number of seconds is:
+                    <=0, then the snapshot for the day will be downloaded
+                         and applied, and also all the logs.
+
+                    >0,  all the required logs are downloaded. This means no
+                         logs if less than 5 min (300 s) downtime, as Darwin
+                         holds 5 minutes of messages in the queue before it
+                         pushes the log to the FTP server and removes the
+                         messages from the waiting queue.
+
+                When the files from FTP are parsed, only the messages that
+                are timestamped by darwin as being sent starting from
+                `current_time - downtime` will be sent to the listener.
+
+        server: FTP server to use. Default: "datafeeds.nationailrail.co.uk".
+        user: FTP username, default None.
+        passwd: FTP password, default None.
+    """
+
+    if type(downtime) is not datetime.timedelta:
+        downtime = datetime.timedelta(seconds=downtime)
+
+    snapshot = downtime.total_seconds() <= 0 or downtime > snapshot_threshold
+    logs = downtime.total_seconds() <= 0 or downtime > log_threshold
+
+    if not snapshot and not logs:
+        log.info("No work needed.")
+        return
+
+    with ftplib.FTP(server) as ftp:
+        login(server, user, passwd)
+
+        if snapshot:
+            get_snapshot(ftp, client)
+
+        if logs:
+            date = datetime.datetime.now() - downtime
+            get_logs(ftp, client, date)
+
+
+def login(ftp, user, passwd):
+    res = ftp.login(user, passwd)
+
+    r = res.split(" ")
+    # be paranoic just in case weird things happened
+    if len(r) < 1:
+        raise LoginFail("Unexpected response message: %s", res)
+
+    # response code
+    resCode = int(r[0])
+    if resCode == 230:
+        # this is the
+        return ftp
+
+    raise LoginFail(res)
+
+def file_callback(ftp, file, callback):
+    """Get a FTP file line by line."""
+    ftp.retrlines("RETR " + file, callback)
+
+def file_to_memory(ftp, file):
+    """Get a whole FTP file in memory as bytes."""
+    bs = bytearray()
+    ftp.retrbinary("RETR " + file, bs.extend)
+    return bs
+
+def _snapshot_filename_key(item):
+    m = _snapshot_pattern.match(item)
+    if not m:
+        return ValueError("item is expected to be a snapshot filename")
+    return datetime.date(
+        year=int(m.group(1)),
+        month=int(m.group(2)),
+        day=int(m.group(3))
+    )
+
+def snapshot_filename(ftp):
+    """Get the filename of the latest snapshot."""
+    files = ftp.nlst()
+    files = [i for i in filter(lambda x: _snapshot_pattern.match(x), files)]
+    if len(files) == 0:
+        log.warning("Could not file any snapshot file!")
+        return None
+
+    if len(files) == 1:
+        return files[0]
+
+    log.warning("Found many snapshot files. Returned the latest one.")
+    mx = max(files, key=_snapshot_filename_key)
+    return mx
+
+def _log_filenames_filter(min_date):
+    min5 = datetime.timedelta(minutes=5)
+
+    def filter_func(item):
+        m = _log_pattern.match(item)
+
+        if not m:
+            return None
+
+        date = datetime.datetime(
+            year = int(m.group(1)),
+            month = int(m.group(2)),
+            day = int(m.group(3)),
+            hour = int(m.group(4)),
+            minute = int(m.group(5))
+        )
+
+        # +min5 because the dates in the filename are the start_dates,
+        # and we don't want to miss any message, in this case:
+        #
+        #                 min_date
+        #           ---------|---------------------> time
+        # blocks:     [   ][ x ][   ][   ][   ]
+        #
+        # So (date >= min_date) == False but we want that file, for the x block.
+
+        return date + min5 >= min_date
+
+    return filter_func
+
+
+def log_filenames(ftp, min_date):
+    """Get log filenames from ftp."""
+    files = ftp.nlst()
+    return filter(_log_filenames_filter(min_date), files)

--- a/darwinpush/ftp.py
+++ b/darwinpush/ftp.py
@@ -2,6 +2,8 @@ import ftplib
 import datetime
 import re
 
+import pyxb.utils.domutils as domutils
+
 import logging
 log = logging.getLogger("ftp")
 
@@ -44,6 +46,8 @@ def fetchAll(client, downtime, server=ftp_server, user=None, passwd=None):
                     <=0, then the snapshot for the day will be downloaded
                          and applied, and also all the logs.
 
+                         NOT YET IMPLEMENTED.
+
                     >0,  all the required logs are downloaded. This means no
                          logs if less than 5 min (300 s) downtime, as Darwin
                          holds 5 minutes of messages in the queue before it
@@ -62,10 +66,11 @@ def fetchAll(client, downtime, server=ftp_server, user=None, passwd=None):
     if type(downtime) is not datetime.timedelta:
         downtime = datetime.timedelta(seconds=downtime)
 
-    snapshot = downtime.total_seconds() <= 0 or downtime > snapshot_threshold
+    #snapshot = downtime.total_seconds() <= 0 or downtime > snapshot_threshold
     logs = downtime.total_seconds() <= 0 or downtime > log_threshold
 
-    if not snapshot and not logs:
+    #if not snapshot and not logs:
+    if not logs:
         log.info("No work needed.")
         return
 
@@ -74,8 +79,8 @@ def fetchAll(client, downtime, server=ftp_server, user=None, passwd=None):
         ftp.maxline = 819100
         login(ftp, user, passwd)
 
-        if snapshot:
-            get_snapshot(ftp, client)
+    #    if snapshot:
+    #        get_snapshot(ftp, client)
 
         if logs:
             date = datetime.datetime.now() - downtime
@@ -108,7 +113,9 @@ def get_logs(ftp, client, date):
         file_callback(ftp, f, callback)
 
 def get_snapshot(ftp, client):
+    """Snapshots not supported yet."""
     pass
+
 
 def file_callback(ftp, file, callback):
     """Get a FTP file line by line."""

--- a/darwinpush/listener.py
+++ b/darwinpush/listener.py
@@ -10,54 +10,54 @@ class Listener:
         print("Running listener")
 
         while not self.quit.is_set():
-            message = self.queue.get()
-            self.route_message(message)
+            (message, source) = self.queue.get()
+            self.route_message(message, source)
 
-    def route_message(self, message):
+    def route_message(self, message, source):
         if type(message) == ScheduleMessage:
-            self.on_schedule_message(message)
+            self.on_schedule_message(message, source)
         elif type(message) == DeactivatedMessage:
-            self.on_deactivated_message(message)
+            self.on_deactivated_message(message, source)
         elif type(message) == AssociationMessage:
-            self.on_association_message(message)
+            self.on_association_message(message, source)
         elif type(message) == TrainStatusMessage:
-            self.on_train_status_message(message)
+            self.on_train_status_message(message, source)
         elif type(message) == StationMessage:
-            self.on_station_message(message)
+            self.on_station_message(message, source)
         elif type(message) == TrainAlertMessage:
-            self.on_train_alert_message(message)
+            self.on_train_alert_message(message, source)
         elif type(message) == TrainOrderMessage:
-            self.on_train_order_message(message)
+            self.on_train_order_message(message, source)
         elif type(message) == TrackingIdMessage:
-            self.on_tracking_id_message(message)
+            self.on_tracking_id_message(message, source)
         elif type(message) == AlarmMessage:
-            self.on_alarm_message(message)
+            self.on_alarm_message(message, source)
         else:
             print("Another type of message")
 
-    def on_schedule_message(self, message):
+    def on_schedule_message(self, message, source):
         pass
 
-    def on_deactivated_message(self, message):
+    def on_deactivated_message(self, message, source):
         pass
 
-    def on_association_message(self, message):
+    def on_association_message(self, message, source):
         pass
 
-    def on_train_status_message(self, message):
+    def on_train_status_message(self, message, source):
         pass
 
-    def on_station_message(self, message):
+    def on_station_message(self, message, source):
         pass
 
-    def on_train_alert_message(self, message):
+    def on_train_alert_message(self, message, source):
         pass
 
-    def on_train_order_message(self, message):
+    def on_train_order_message(self, message, source):
         pass
 
-    def on_tracking_id_message(self, message):
+    def on_tracking_id_message(self, message, source):
         pass
 
-    def on_alarm_message(self, message):
+    def on_alarm_message(self, message, source):
         pass

--- a/darwinpush/parser.py
+++ b/darwinpush/parser.py
@@ -13,10 +13,10 @@ class Parser:
 
     def run(self):
         while not self.quit.is_set():
-            (m, message) = self.q_in.get()
-            self.parse(m, message)
+            (m, message, source) = self.q_in.get()
+            self.parse(m, message, source)
 
-    def parse(self, m, message):
+    def parse(self, m, message, source):
         # We aren't ever expecting the Snapshot Record component to contain anything.
         if m.sR is not None:
             print("o.O.o.O Snapshot record is not none.")
@@ -34,52 +34,52 @@ class Parser:
         for i in r.schedule:
             log.debug("SCHEDULE message received.")
             o = ScheduleXMLMessageFactory.build(i, m, message)
-            self.q_out.put(o)
+            self.q_out.put((o, source))
 
         # Process DEACTIVATED messages.
         for i in r.deactivated:
             log.debug("DEACTIVATED message received.")
             o = DeactivatedMessage(i, m, message)
-            self.q_out.put(o)
+            self.q_out.put((o, source))
 
         # Process ASSOCATION messages.
         for i in r.association:
             log.debug("ASSOCIATION message received.")
             o = AssociationMessage(i, m, message)
-            self.q_out.put(o)
+            self.q_out.put((o, source))
 
         # Process TS messages.
         for i in r.TS:
             log.debug("TS message received.")
             o = TrainStatusXMLMessageFactory.build(i, m, message)
-            self.q_out.put(o)
+            self.q_out.put((o, source))
 
         # Process OW messages.
         for i in r.OW:
             log.debug("OW message received.")
             o = StationMessage(i, m, message)
-            self.q_out.put(o)
+            self.q_out.put((o, source))
 
         # Process TRAINALERT messages.
         for i in r.trainAlert:
             log.debug("TRAINALERT message received.")
             o = TrainAlertMessage(i, m, message)
-            self.q_out.put(o)
+            self.q_out.put((o, source))
 
         # Process TRAINORDER messages.
         for i in r.trainOrder:
             log.debug("TRAINORDER message received.")
             o = TrainOrderMessage(i, m, message)
-            self.q_out.put(o)
+            self.q_out.put((o, source))
 
         # Process TRACKINGID messages.
         for i in r.trackingID:
             log.debug("TRACKINGID message received.")
             o = TrackingIdMessage(i, m, message)
-            self.q_out.put(o)
+            self.q_out.put((o, source))
 
         # Process ALARM messages.
         for i in r.alarm:
             log.debug("ALARM message received.")
             o = AlarmMessage(i, m, message)
-            self.q_out.put(o)
+            self.q_out.put((o, source))

--- a/example.py
+++ b/example.py
@@ -17,31 +17,31 @@ class MyListener(Listener):
     def now(self):
         return time.strftime("%d/%m/%y %H:%M:%S")
 
-    def on_schedule_message(self, message):
+    def on_schedule_message(self, message, source):
         print(self.now(), "Schedule")
 
-    def on_deactivated_message(self, message):
+    def on_deactivated_message(self, message, source):
         print(self.now(), "Deactivated message")
 
-    def on_association_message(self, message):
+    def on_association_message(self, message, source):
         print(self.now(), "Association")
 
-    def on_alarm_message(self, message):
+    def on_alarm_message(self, message, source):
         print(self.now(), "Alarm message")
 
-    def on_station_message(self, message):
+    def on_station_message(self, message, source):
         print(self.now(), "Station message")
 
-    def on_tracking_id_message(self, message):
+    def on_tracking_id_message(self, message, source):
         print(self.now(), "Tracking ID message")
 
-    def on_train_alert_message(self, message):
+    def on_train_alert_message(self, message, source):
         print(self.now(), "Train alert message")
 
-    def on_train_order_message(self, message):
+    def on_train_order_message(self, message, source):
         print(self.now(), "Train order message")
 
-    def on_train_status_message(self, message):
+    def on_train_status_message(self, message, source):
         print(self.now(), "Train status message")
 
 if __name__ == "__main__":

--- a/example.py
+++ b/example.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
         MyListener
     )
 
-    # Connect the Push Port client.
+    # Connect the Push Port client. No FTP connection at all!
     client.connect()
     print("Connected")
     try:

--- a/example_ftp.py
+++ b/example_ftp.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+from darwinpush import Client, Listener
+from darwinpush.messages.AssociationMessage import AssociationCategory
+
+import os
+import time
+
+# Create a listener to process the messages.
+class MyListener(Listener):
+    def __init__(self, q, quit_event):
+        # Any setup if needed.
+
+        # Finally, call the Super Class initialiser.
+        super().__init__(q, quit_event)
+
+    def now(self):
+        return time.strftime("%d/%m/%y %H:%M:%S")
+
+    def on_schedule_message(self, message, source):
+        print(self.now(), source, "Schedule")
+
+    def on_deactivated_message(self, message, source):
+        print(self.now(), source, "Deactivated message")
+
+    def on_association_message(self, message, source):
+        print(self.now(), source, "Association")
+
+    def on_alarm_message(self, message, source):
+        print(self.now(), source, "Alarm message")
+
+    def on_station_message(self, message, source):
+        print(self.now(), source, "Station message")
+
+    def on_tracking_id_message(self, message, source):
+        print(self.now(), source, "Tracking ID message")
+
+    def on_train_alert_message(self, message, source):
+        print(self.now(), source, "Train alert message")
+
+    def on_train_order_message(self, message, source):
+        print(self.now(), source, "Train order message")
+
+    def on_train_status_message(self, message, source):
+        print(self.now(), source, "Train status message")
+
+if __name__ == "__main__":
+    # Instantiate the Push Port client.
+    client = Client(
+        os.environ["STOMP_USER"],
+        os.environ["STOMP_PASS"],
+        os.environ["STOMP_QUEUE"],
+        MyListener,
+        ftp_user=os.environ["FTP_USER"],
+        ftp_passwd=os.environ["FTP_PASSWD"]
+    )
+
+    # Do not connect to stomp, just download and parse the logs from FTP for
+    # the last `downtime` seconds and quit.
+    client.connect(downtime=600, stomp=False)
+    print("All done. Bye :)")
+    client.disconnect()

--- a/tests/test_ftp.py
+++ b/tests/test_ftp.py
@@ -1,0 +1,104 @@
+import os
+import sys
+sys.path.append(os.getcwd())
+
+import datetime
+
+import pytest
+import darwinpush.ftp as ftp
+
+
+class FakeFtp():
+    def __init__(self, files):
+        self.files = files
+
+    def nlst(self):
+        """ Fake listing all the files """
+        return self.files
+
+
+def test_log_filenames():
+    fakeftp = FakeFtp([
+        "20150926020724_ref_v3.xml.gz",
+        "20150926020724_v8.xml.gz",
+        "pPortData.log.2015-09-26-09-44",
+        "pPortData.log.2015-09-26-09-49",
+        "pPortData.log.2015-09-26-09-54",
+        "pPortData.log.2015-09-26-09-59", # all files including this one
+        "pPortData.log.2015-09-26-10-04",
+        "pPortData.log.2015-09-26-10-09",
+        "pPortData.log.2015-09-26-10-14",
+        "pPortData.log.2015-09-26-10-19",
+        "some weird stuff",
+        "pPortData.log.2015-09-26-10-24",
+        "pPortData.log.2015-09-26-10-29",
+        "pPortData.log.2015-09-26-10-34",
+        "pPortData.log",
+    ])
+
+    min_date = datetime.datetime(
+        year=2015,
+        month=9,
+        day=26,
+        hour=10,
+        minute=2
+    )
+
+    # manually filter the names
+    index = fakeftp.files.index("pPortData.log.2015-09-26-09-59")
+    expected = [i for i in filter(
+        lambda x: x!="some weird stuff",
+        fakeftp.files[index:len(fakeftp.files)-1]
+    )]
+
+    result = [i for i in ftp.log_filenames(fakeftp, min_date)]
+    assert(result == expected)
+
+def test_snapshot_filename():
+    fakeftp = FakeFtp([
+        "20150926020724_ref_v3.xml.gz",
+        "pPortData.log.2015-09-26-09-44",
+        "pPortData.log.2015-09-26-09-49",
+        "20150926020724_v8.xml.gz",
+        "pPortData.log.2015-09-26-09-54",
+        "pPortData.log.2015-09-26-09-59",
+        "pPortData.log.2015-09-26-10-04",
+        "pPortData.log.2015-09-26-10-09",
+        "pPortData.log.2015-09-26-10-14",
+        "pPortData.log.2015-09-26-10-19",
+        "some weird stuff",
+        "pPortData.log.2015-09-26-10-24",
+        "pPortData.log.2015-09-26-10-29",
+        "pPortData.log.2015-09-26-10-34",
+        "pPortData.log",
+    ])
+
+    result = ftp.snapshot_filename(fakeftp)
+    assert(result == "20150926020724_v8.xml.gz")
+
+def test_snapshot_filename_none():
+    fakeftp = FakeFtp([
+        "pPortData.log.2015-09-26-09-44",
+        "pPortData.log.2015-09-26-09-49",
+        "pPortData.log.2015-09-26-09-54",
+        "pPortData.log.2015-09-26-09-59",
+        "pPortData.log.2015-09-26-10-04",
+    ])
+
+    result = ftp.snapshot_filename(fakeftp)
+    assert(result == None)
+
+def test_snapshot_filename_more():
+    fakeftp = FakeFtp([
+        "20150925020724_v8.xml.gz",
+        "haha",
+        "20150926020724_v8.xml.gz", # this is the maximum
+        "some weird stuff",
+        "pPortData.log.2015-09-26-10-24",
+        "20150826020724_v8.xml.gz",
+        "pPortData.log.2015-09-26-10-29",
+        "pPortData.log.2015-09-26-10-34",
+    ])
+
+    result = ftp.snapshot_filename(fakeftp)
+    assert(result == "20150926020724_v8.xml.gz")


### PR DESCRIPTION
This makes Client to take a `downtime` parameter using which the number of logs to download over FTP is determined.

The FTP logs are then downloaded and sent to the listener as they came from STOMP.

A new parameter `source` was added at the `on_*_message` methods, which has the value `"stomp"` if the messages comes from STOMP or `"FTP/log"` if the message comes from FTP logs.

The snapshots are not implemented because the XML has a slightly different format and dealing with it is either hacky or requires really major refactoring.
